### PR TITLE
Fix: should be able to type into textarea input element

### DIFF
--- a/src/components/__tests__/CanvasHeadline.test.tsx
+++ b/src/components/__tests__/CanvasHeadline.test.tsx
@@ -11,7 +11,7 @@ describe("CanvasHeadlines.tsx tests", () => {
       </CanvasPreviewContextProvider>
     );
     const textAreaElement = screen.getByPlaceholderText(
-      /Leave a comment here/i
+      /Enter headline text here/i
     ) as HTMLInputElement;
     fireEvent.change(textAreaElement, {
       target: { value: "Text for the headline component" },


### PR DESCRIPTION
This PR fixes a failing test for the CanvasHeadline component.